### PR TITLE
Core - Fix NPE, AIOOBE  fix_codex_0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,22 @@
 name: ChaosTree Cross-System CI
 
 on:
-  pull_request:
-    branches: [ "main", "master" ]
-
   push:
+    branches:
+      - main
+      - core
+      - test
+      - benchmark
     tags:
-      - '*'
+      - 'v*'
+
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
     name: Build & Test on ${{ matrix.os }} (Java ${{ matrix.java }})
-
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -25,13 +30,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: temurin
           cache: maven
 
       - name: Run ChaosTree Test Suite
-        shell: bash
-        run: |
-          mvn clean test -B
+        env:
+          MAVEN_OPTS: "-Xmx2g"
+        run: mvn clean test -B

--- a/chaos-tree/src/main/java/chaos/tree/nary/AbstractNaryTreeSet.java
+++ b/chaos-tree/src/main/java/chaos/tree/nary/AbstractNaryTreeSet.java
@@ -36,6 +36,7 @@ sealed abstract class AbstractNaryTreeSet<E, N extends AbstractNaryNode<E, N>> e
     private static final String RESET = "\u001B[0m";
     private static final String CYAN = "\u001B[1;38;2;0;229;255m";       // #00E5FF
     private static final String STRUCTURE = "\u001B[38;2;84;110;122m";        // #546E7A
+    private static final String BRIGHT_WHITE = "\u001B[97m";
     protected final int degree;
     protected final int maxKeys;
     protected final int minKeys;
@@ -57,7 +58,7 @@ sealed abstract class AbstractNaryTreeSet<E, N extends AbstractNaryNode<E, N>> e
         this.minKeys = degree - 1;
     }
 
-    abstract void buildFromSorted(Iterator<E> it, float f);
+    abstract void buildFromSorted(Iterator<? extends E> it, float f);
 
     @SuppressWarnings("unchecked")
     protected int compare(E e1, E e2) {
@@ -322,8 +323,7 @@ sealed abstract class AbstractNaryTreeSet<E, N extends AbstractNaryNode<E, N>> e
 
         sb.append(prefix).append(isTail ? lastBranch : crossBranch);
 
-        sb.append(STRUCTURE).append(prefix).append(isTail ? lastBranch : crossBranch).append(RESET);
-        sb.append(STRUCTURE).append("[").append(RESET);
+        sb.append(BRIGHT_WHITE).append("[").append(RESET);
 
         for (int i = 0; i < node.keyCount; i++) {
             sb.append(CYAN).append(node.keys[i]).append(RESET);
@@ -331,7 +331,7 @@ sealed abstract class AbstractNaryTreeSet<E, N extends AbstractNaryNode<E, N>> e
                 sb.append(STRUCTURE).append(", ").append(RESET);
             }
         }
-        sb.append(STRUCTURE).append("]").append(RESET).append("\n");
+        sb.append(BRIGHT_WHITE).append("]").append(RESET).append("\n");
 
         if (!node.isLeaf()) {
             int numChildren = node.keyCount + 1;

--- a/chaos-tree/src/main/java/chaos/tree/nary/BPlusTreeSet.java
+++ b/chaos-tree/src/main/java/chaos/tree/nary/BPlusTreeSet.java
@@ -73,84 +73,104 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
      * ascending order according to this tree's comparator. If the data is unsorted,
      * the tree structure will be corrupted.
      *
-     * @param sorted An iterator providing strictly sorted elements.
-     * @param fillFactor A value between 0.5 and 1.0 representing how full to pack each node.
+     * @param it An iterator providing strictly sorted elements.
+     * @param factor A value between 0.5 and 1.0 representing how full to pack each node.
      *                   Use 1.0 for read-only data, or lower to leave room for future insertions.
      *                   A use of 0.9f is used for bulk loading in my tree. For read purpose you can
      *                   have it 1.0f but after that any insert or remove information will
      *                   trigger massive split, merge, borrow, array shifting.
      */
     @Override
-    public void buildFromSorted(Iterator<E> sorted, float fillFactor) {
+    @SuppressWarnings("unchecked")
+    void buildFromSorted(Iterator<? extends E> it, float factor) {
         if (!isEmpty()) {
             throw new IllegalStateException("Bulk load is only permitted on an empty tree.");
         }
-        if (fillFactor < 0.5f || fillFactor > 1.0f) {
+        if (factor < 0.5f || factor > 1.0f) {
             throw new IllegalArgumentException("Fill factor must be between 0.5 and 1.0");
         }
-        int targetKeys = Math.max(minKeys, (int) (maxKeys * fillFactor)); //This is most important I came to mark it agin
-
-        @SuppressWarnings("unchecked")
-        BPlusTreeNode<E>[] rightEdge = new BPlusTreeNode[64];
-
-        int height = 0;
+        int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
+        BPlusTreeNode<E>[] rightEdge = (BPlusTreeNode<E>[]) new BPlusTreeNode[32];
         rightEdge[0] = createNode(degree, true);
-        root = rightEdge[0];
+        this.root = rightEdge[0];
 
-        while (sorted.hasNext()) {
-            BPlusTreeNode<E> rightLeaf = rightEdge[0];
+        while (it.hasNext()) {
+            E element = it.next();
+            BPlusTreeNode<E> leaf = rightEdge[0];
 
-            if (rightLeaf.keyCount < targetKeys) {//The diff!!
-                rightLeaf.keys[rightLeaf.keyCount++] = sorted.next();
-                size++;
+            if (leaf.keyCount < targetKeys) {
+                leaf.keys[leaf.keyCount] = element;
+                leaf.keyCount++;
+                this.size++;
             } else {
-                // The VERY NEXT element is our routing key.
-                // We need to pull it from the iterator, but we will duplicate it later!
-                E routingKey = sorted.next();
-                size++;
+                BPlusTreeNode<E> newLeaf = createNode(degree, true);
+                leaf.next = newLeaf;
+                newLeaf.prev = leaf;
+
+                newLeaf.keys[0] = element;
+                newLeaf.keyCount = 1;
+                this.size++;
+
+                E routingKey = element;
+                BPlusTreeNode<E> leftChild = leaf;
+                BPlusTreeNode<E> rightChild = newLeaf;
+
+                rightEdge[0] = newLeaf;
 
                 int level = 1;
-                while (level <= height && rightEdge[level].keyCount == targetKeys) {
-                    level++;
-                }
+                while (true) {
+                    BPlusTreeNode<E> parent = rightEdge[level];
 
-                // Height Crisis
-                if (level > height) {
-                    height++;
-                    BPlusTreeNode<E> newRoot = createNode(degree, false);
-                    newRoot.child[0] = rightEdge[height - 1];
-                    rightEdge[height - 1].parent = newRoot;
-
-                    rightEdge[height] = newRoot;
-                    root = newRoot;
-                }
-
-                // Drop the routing key COPY into the internal node!
-                BPlusTreeNode<E> targetNode = rightEdge[level];
-                targetNode.keys[targetNode.keyCount++] = routingKey;
-
-                // 3. REBUILD DOWNWARD
-                for (int i = level - 1; i >= 0; i--) {
-                    BPlusTreeNode<E> newNode = createNode(degree, i == 0);
-                    if (i == 0) {
-                        BPlusTreeNode<E> oldLeaf = rightEdge[0];
-                        oldLeaf.next = newNode;
-                        newNode.prev = oldLeaf;
+                    if (parent == null) {
+                        parent = createNode(degree, false);
+                        parent.setChild(0, leftChild);
+                        rightEdge[level] = parent;
+                        this.root = parent;
                     }
 
-                    rightEdge[i + 1].child[rightEdge[i + 1].keyCount] = newNode;
-                    newNode.parent = rightEdge[i + 1];
+                    if (parent.keyCount < targetKeys) {
+                        parent.keys[parent.keyCount] = routingKey;
+                        parent.setChild(parent.keyCount + 1, rightChild);
+                        parent.keyCount++;
+                        break;
+                    } else {
+                        BPlusTreeNode<E> newInternal = createNode(degree, false);
+                        newInternal.setChild(0, rightChild);
+                        rightEdge[level] = newInternal;
 
-                    rightEdge[i] = newNode;
+                        leftChild = parent;
+                        rightChild = newInternal;
+                        level++;
+                    }
                 }
-
-                // Because B+Tree stores all actual data in the leaves,
-                // the routing key we just pushed UP must also be pushed DOWN into the new empty leaf!
-                rightEdge[0].keys[rightEdge[0].keyCount++] = routingKey;
             }
         }
-    }
 
+        for (int level = 1; level < 32; level++) {
+            BPlusTreeNode<E> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BPlusTreeNode<E> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BPlusTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                if (node.child[0] != null) node.child[0].parent = node;
+
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
+        }
+        this.modCount++;
+    }
     /**
      * Strictly sorted array data directly into the tree in O(N) time.
      * <p>
@@ -189,67 +209,88 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
 
     @SuppressWarnings("unchecked")
     private void buildFromSortedArray(Object[] blast, float factor) {
-        int targetKeys = Math.max(minKeys, (int) (maxKeys * factor)); //came for this fix!!
+        int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
+        int totalSize = blast.length;
+        if (totalSize == 0) return;
 
-        @SuppressWarnings("unchecked")
         BPlusTreeNode<E>[] rightEdge = (BPlusTreeNode<E>[]) new BPlusTreeNode[32];
-        rightEdge[0] = new BPlusTreeNode<>(degree, true);
+        rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
 
-        int index = 0;
-        while (index < blast.length) {
+        int i = 0;
+        while (i < totalSize) {
             BPlusTreeNode<E> leaf = rightEdge[0];
-            int chunk = Math.min(targetKeys, blast.length - index);
-            System.arraycopy(blast, index, leaf.keys, 0, chunk);
-            leaf.keyCount = chunk;
-            this.size += chunk;
-            index += chunk;
+            int chunk = Math.min(targetKeys - leaf.keyCount, totalSize - i);
+            System.arraycopy(blast, i, leaf.keys, leaf.keyCount, chunk);
+            leaf.keyCount += chunk;
+            i += chunk;
 
-            if (index < blast.length) {
-                @SuppressWarnings("unchecked")
-                E routingKey = (E) blast[index];
+            if (i < totalSize) {
+                E routingKey = (E) blast[i]; // B+Tree doesn't consume the element
 
                 int level = 1;
                 while (true) {
-                    if (rightEdge[level] == null) {
-                        BPlusTreeNode<E> newRoot = new BPlusTreeNode<>(degree, false);
-                        newRoot.setChild(0, rightEdge[level - 1]);
-                        rightEdge[level] = newRoot;
-                        this.root = newRoot;
+                    BPlusTreeNode<E> parent = rightEdge[level];
+                    if (parent == null) {
+                        parent = createNode(degree, false);
+                        parent.setChild(0, rightEdge[level - 1]);
+                        rightEdge[level] = parent;
+                        this.root = parent;
                     }
 
-                    BPlusTreeNode<E> targetNode = rightEdge[level];
-                    targetNode.keys[targetNode.keyCount++] = routingKey;
+                    if (parent.keyCount < targetKeys) {
+                        parent.keys[parent.keyCount] = routingKey;
+                        parent.keyCount++;
 
-                    BPlusTreeNode<E> nextRight = new BPlusTreeNode<>(degree, (level - 1) == 0);
-                    targetNode.setChild(targetNode.keyCount, nextRight);
-                    if (level - 1 == 0) {
-                        rightEdge[0].next = nextRight;
-                        nextRight.prev = rightEdge[0];
-                    }
-                    rightEdge[level - 1] = nextRight;
+                        BPlusTreeNode<E> prevInternal = parent;
+                        for (int d = level - 1; d >= 0; d--) {
+                            BPlusTreeNode<E> newNode = createNode(degree, d == 0);
+                            prevInternal.setChild(prevInternal.keyCount, newNode);
 
-                    if (targetNode.keyCount < targetKeys) {
-                        for (int i = level - 2; i >= 0; i--) {
-                            BPlusTreeNode<E> fillNode = new BPlusTreeNode<>(degree, i == 0);
-                            rightEdge[i + 1].setChild(0, fillNode);
-                            if (i == 0) {
-                                rightEdge[0].next = fillNode;
-                                fillNode.prev = rightEdge[0];
+                            if (d == 0) {
+                                rightEdge[0].next = newNode;
+                                newNode.prev = rightEdge[0];
                             }
-                            rightEdge[i] = fillNode;
+
+                            rightEdge[d] = newNode;
+                            prevInternal = newNode;
                         }
                         break;
+                    } else {
+                        level++;
                     }
-                    routingKey = (E) targetNode.keys[targetNode.keyCount - 1];
-                    targetNode.keys[targetNode.keyCount - 1] = null;
-                    targetNode.keyCount--;
-                    level++;
                 }
             }
         }
+
+        for (int level = 1; level < 32; level++) {
+            BPlusTreeNode<E> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BPlusTreeNode<E> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BPlusTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                node.child[0].parent = node;
+
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
+        }
+
+        this.size = totalSize;
         this.modCount++;
     }
+
 
     @Override
     @SuppressWarnings("unchecked")
@@ -739,7 +780,7 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
             return this;
         }
 
-        public BPlusTreeSet.Builder<E> importFlatArray(Object[] flatArray) {
+        public BPlusTreeSet.Builder<E> importFlatMatrix(Object[] flatArray) {
             this.flatArray = flatArray;
             this.sortedIterator = null;
             this.collection = null;

--- a/chaos-tree/src/main/java/chaos/tree/nary/BPlusTreeSet.java
+++ b/chaos-tree/src/main/java/chaos/tree/nary/BPlusTreeSet.java
@@ -146,6 +146,30 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
             }
         }
 
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BPlusTreeNode<E> node = rightEdge[0];
+            BPlusTreeNode<E> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BPlusTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+                parent.keys[childIdx - 1] = node.keys[0];
+            } else {
+                parent.keys[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+
+                leftSib.next = node.next;
+                if (leftSib.next != null) {
+                    leftSib.next.prev = leftSib;
+                }
+            }
+        }
+
         for (int level = 1; level < 32; level++) {
             BPlusTreeNode<E> node = rightEdge[level];
             if (node == null) break;
@@ -154,20 +178,30 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
                 int childIdx = parent.keyCount;
                 BPlusTreeNode<E> leftSib = parent.child[childIdx - 1];
 
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                if (node.child[0] != null) node.child[0].parent = node;
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+                    if (node.child[0] != null) node.child[0].parent = node;
 
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
         this.modCount++;
     }
@@ -213,7 +247,7 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
         int totalSize = blast.length;
         if (totalSize == 0) return;
 
-        BPlusTreeNode<E>[] rightEdge = (BPlusTreeNode<E>[]) new BPlusTreeNode[32];
+        BPlusTreeNode<E>[] rightEdge = (BPlusTreeNode<E>[]) new BPlusTreeNode[10];
         rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
 
@@ -263,7 +297,31 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
             }
         }
 
-        for (int level = 1; level < 32; level++) {
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BPlusTreeNode<E> node = rightEdge[0];
+            BPlusTreeNode<E> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BPlusTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+                parent.keys[childIdx - 1] = node.keys[0];
+            } else {
+                parent.keys[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+
+                leftSib.next = node.next;
+                if (leftSib.next != null) {
+                    leftSib.next.prev = leftSib;
+                }
+            }
+        }
+
+        for (int level = 0; level < 10; level++) {
             BPlusTreeNode<E> node = rightEdge[level];
             if (node == null) break;
             if (node.keyCount == 0 && node != this.root) {
@@ -271,20 +329,30 @@ public final class BPlusTreeSet<E> extends AbstractNaryTreeSet<E, BPlusTreeNode<
                 int childIdx = parent.keyCount;
                 BPlusTreeNode<E> leftSib = parent.child[childIdx - 1];
 
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                node.child[0].parent = node;
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+                    if (node.child[0] != null) node.child[0].parent = node;
 
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
 
         this.size = totalSize;

--- a/chaos-tree/src/main/java/chaos/tree/nary/BTreeSet.java
+++ b/chaos-tree/src/main/java/chaos/tree/nary/BTreeSet.java
@@ -222,6 +222,26 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
                 }
             }
         }
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BTreeNode<E> node = rightEdge[0];
+            BTreeNode<E> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = parent.keys[childIdx - 1];
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            } else {
+                leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                leftSib.keyCount++;
+                parent.keys[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+            }
+        }
 
         for (int level = 1; level < 32; level++) {
             BTreeNode<E> node = rightEdge[level];
@@ -230,19 +250,31 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
                 BTreeNode<E> parent = rightEdge[level + 1];
                 int childIdx = parent.keyCount;
                 BTreeNode<E> leftSib = parent.child[childIdx - 1];
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                if (node.child[0] != null) node.child[0].parent = node;
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+
+                    if (node.child[0] != null) node.child[0].parent = node;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
         this.modCount++;
     }
@@ -289,7 +321,7 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
         int totalSize = sortedArray.length;
         if (totalSize == 0) return;
 
-        BTreeNode<E>[] rightEdge = (BTreeNode<E>[]) new BTreeNode[32];
+        BTreeNode<E>[] rightEdge = (BTreeNode<E>[]) new BTreeNode[10];
         rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
 
@@ -334,7 +366,28 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
             }
         }
 
-        for (int level = 1; level < 32; level++) {
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BTreeNode<E> node = rightEdge[0];
+            BTreeNode<E> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = parent.keys[childIdx - 1];
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            } else {
+                leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                leftSib.keyCount++;
+                parent.keys[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+            }
+        }
+
+        for (int level = 1; level < 10; level++) {
             BTreeNode<E> node = rightEdge[level];
             if (node == null) break;
             if (node.keyCount == 0 && node != this.root) {
@@ -342,20 +395,30 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
                 int childIdx = parent.keyCount;
                 BTreeNode<E> leftSib = parent.child[childIdx - 1];
 
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                node.child[0].parent = node;
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
 
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+                    if (node.child[0] != null) node.child[0].parent = node;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
 
         this.size = totalSize;

--- a/chaos-tree/src/main/java/chaos/tree/nary/BTreeSet.java
+++ b/chaos-tree/src/main/java/chaos/tree/nary/BTreeSet.java
@@ -174,65 +174,77 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
      * turn the observation into a deterministic construction strategy.
      * </pre>
      */
-    void buildFromSorted(Iterator<E> it, float fillFactor) {
-        // Calculate the future mighty chaos target (e.g., 0.75 * 63 = 47 keys per node)
-        /*
-        Well lemme explain it. If I banged with 100% node capacity there will a tremendous trigger of merge and split node LOL
-         */
-        int targetKeys = Math.max(minKeys, (int) (maxKeys * fillFactor));
-        // Track the right-most path of the tree (index 0 is the Leaf layer)
-        @SuppressWarnings("unchecked")
-        BTreeNode<E>[] rightEdge = new BTreeNode[64]; // 64 2,3,4 trees structure rest will never touch that depth LOL
-
-        int height = 0;
+    @Override
+    @SuppressWarnings("unchecked")
+    void buildFromSorted(Iterator<? extends E> it, float factor) {
+        int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
+        BTreeNode<E>[] rightEdge = (BTreeNode<E>[]) new BTreeNode[32];
         rightEdge[0] = createNode(degree, true);
-        root = rightEdge[0];
+        this.root = rightEdge[0];
 
         while (it.hasNext()) {
-            BTreeNode<E> rightLeaf = rightEdge[0];
+            BTreeNode<E> leaf = rightEdge[0];
+            while (leaf.keyCount < targetKeys && it.hasNext()) {
+                leaf.keys[leaf.keyCount] = it.next();
+                leaf.keyCount++;
+                this.size++;
+            }
 
-            if (rightLeaf.keyCount < targetKeys) {
-                // 1. FAST APPEND: Shove the data into the leaf!
-                rightLeaf.keys[rightLeaf.keyCount++] = it.next();
-                size++;
-            } else {
-                // The VERY NEXT element acts as the routing key up above!
-                E routingKey = it.next();
-                size++;
+            if (it.hasNext()) {
+                E sepKey = it.next();
+                this.size++;
 
-                // Find the lowest level on the right edge that has room for the routing key
                 int level = 1;
-                while (level <= height && rightEdge[level].keyCount == targetKeys) {
-                    level++;
-                }
-                // If I ran out of height grow the tree upwards! (New Root)
-                if (level > height) {
-                    height++;
-                    BTreeNode<E> newRoot = createNode(degree, false);
-                    newRoot.child[0] = rightEdge[height - 1]; // Link old root
-                    rightEdge[height - 1].parent = newRoot;      // Set parent pointer!
+                while (true) {
+                    BTreeNode<E> parent = rightEdge[level];
+                    if (parent == null) {
+                        parent = createNode(degree, false);
+                        parent.setChild(0, rightEdge[level - 1]);
+                        rightEdge[level] = parent;
+                        this.root = parent;
+                    }
 
-                    rightEdge[height] = newRoot;
-                    root = newRoot;
-                }
-                // Insert the routing key into the target level
-                BTreeNode<E> targetNode = rightEdge[level];
-                targetNode.keys[targetNode.keyCount++] = routingKey;
-                // 3. REBUILD DOWNWARD: Create a fresh empty path down to the leaf layer
-                for (int i = level - 1; i >= 0; i--) {
-                    BTreeNode<E> newNode = createNode(degree, i == 0);
-                    // Link it to the parent above it
-                    rightEdge[i + 1].child[rightEdge[i + 1].keyCount] = newNode;
-                    newNode.parent = rightEdge[i + 1]; // Set parent pointer!
-                    // Update tracking array
-                    rightEdge[i] = newNode;
+                    if (parent.keyCount < targetKeys) {
+                        parent.keys[parent.keyCount] = sepKey;
+                        parent.keyCount++;
+
+                        BTreeNode<E> prevInternal = parent;
+                        for (int d = level - 1; d >= 0; d--) {
+                            BTreeNode<E> newNode = createNode(degree, d == 0);
+                            prevInternal.setChild(prevInternal.keyCount, newNode);
+                            rightEdge[d] = newNode;
+                            prevInternal = newNode;
+                        }
+                        break;
+                    } else {
+                        level++;
+                    }
                 }
             }
         }
 
-        // Optional: If the very last leaf didn't reach minKeys, the B-Tree rules technically
-        // allow the right-most edge to be underfull immediately after a bulk load.
-        // Future inserts will naturally fix it!
+        for (int level = 1; level < 32; level++) {
+            BTreeNode<E> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BTreeNode<E> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BTreeNode<E> leftSib = parent.child[childIdx - 1];
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                if (node.child[0] != null) node.child[0].parent = node;
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
+        }
+        this.modCount++;
     }
 
     /**
@@ -273,60 +285,83 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
 
     @SuppressWarnings("unchecked")
     private void buildFromSortedArray(Object[] sortedArray, float fillFactor) {
-        int targetKeys = Math.max(minKeys, (int) (maxKeys * fillFactor)); //came for this fix
+        int targetKeys = Math.max(minKeys, (int) (maxKeys * fillFactor));
+        int totalSize = sortedArray.length;
+        if (totalSize == 0) return;
 
         BTreeNode<E>[] rightEdge = (BTreeNode<E>[]) new BTreeNode[32];
-        rightEdge[0] = new BTreeNode<>(degree, true);
+        rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
 
-        int index = 0;
-        while (index < sortedArray.length) {
+        int i = 0;
+        while (i < totalSize) {
             BTreeNode<E> leaf = rightEdge[0];
-            int chunk = Math.min(targetKeys, sortedArray.length - index);
-            System.arraycopy(sortedArray, index, leaf.keys, 0, chunk);
-            leaf.keyCount = chunk;
-            this.size += chunk;
-            index += chunk;
+            int chunk = Math.min(targetKeys - leaf.keyCount, totalSize - i);
+            System.arraycopy(sortedArray, i, leaf.keys, leaf.keyCount, chunk);
+            leaf.keyCount += chunk;
+            i += chunk;
 
-            if (index < sortedArray.length) {
-                @SuppressWarnings("unchecked")
-                E routingKey = (E) sortedArray[index++];
-                this.size++;
+            if (i < totalSize) {
+                E sepKey = (E) sortedArray[i];
+                i++;
 
                 int level = 1;
                 while (true) {
-                    if (rightEdge[level] == null) {
-                        BTreeNode<E> newRoot = new BTreeNode<>(degree, false);
-                        newRoot.setChild(0, rightEdge[level - 1]);
-                        rightEdge[level] = newRoot;
-                        this.root = newRoot;
+                    BTreeNode<E> parent = rightEdge[level];
+                    if (parent == null) {
+                        parent = createNode(degree, false);
+                        parent.setChild(0, rightEdge[level - 1]);
+                        rightEdge[level] = parent;
+                        this.root = parent;
                     }
 
-                    BTreeNode<E> targetNode = rightEdge[level];
-                    targetNode.keys[targetNode.keyCount++] = routingKey;
+                    if (parent.keyCount < targetKeys) {
+                        parent.keys[parent.keyCount] = sepKey;
+                        parent.keyCount++;
 
-                    BTreeNode<E> nextRight = new BTreeNode<>(degree, (level - 1) == 0);
-                    targetNode.setChild(targetNode.keyCount, nextRight);
-                    rightEdge[level - 1] = nextRight;
-
-                    if (targetNode.keyCount < targetKeys) {
-                        for (int i = level - 2; i >= 0; i--) {
-                            BTreeNode<E> fillNode = new BTreeNode<>(degree, i == 0);
-                            rightEdge[i + 1].setChild(0, fillNode);
-                            rightEdge[i] = fillNode;
+                        BTreeNode<E> prevInternal = parent;
+                        for (int d = level - 1; d >= 0; d--) {
+                            BTreeNode<E> newNode = createNode(degree, d == 0);
+                            prevInternal.setChild(prevInternal.keyCount, newNode);
+                            rightEdge[d] = newNode;
+                            prevInternal = newNode;
                         }
                         break;
+                    } else {
+                        level++;
                     }
-
-                    routingKey = (E) targetNode.keys[targetNode.keyCount - 1];
-                    targetNode.keys[targetNode.keyCount - 1] = null;
-                    targetNode.keyCount--;
-                    level++;
                 }
             }
         }
+
+        for (int level = 1; level < 32; level++) {
+            BTreeNode<E> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BTreeNode<E> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BTreeNode<E> leftSib = parent.child[childIdx - 1];
+
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                node.child[0].parent = node;
+
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
+        }
+
+        this.size = totalSize;
         this.modCount++;
     }
+
 
     @Override
     BTreeNode<E> createNode(int degree, boolean isLeaf) {
@@ -551,6 +586,7 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
                 // Must Merge (Smasher)
                 if (leftSibling != null) {
                     mergeNodes(parent, childIdx - 1, leftSibling, current);
+                    current = parent; //You fool I will remember you :(=  Ahhh....10hr wasted on this day 5sep!!
                 } else {
                     mergeNodes(parent, childIdx, current, rightSibling);
                     // The parent lost a key, so underflow bubbles UP!
@@ -829,7 +865,7 @@ public final class BTreeSet<E> extends AbstractNaryTreeSet<E, BTreeNode<E>> {
             return this;
         }
 
-        public BTreeSet.Builder<E> importFlatArray(Object[] flatArray) {
+        public BTreeSet.Builder<E> importFlatMatrix(Object[] flatArray) {
             this.flatArray = flatArray;
             this.sortedIterator = null;
             this.collection = null;

--- a/chaos-tree/src/main/java/chaos/tree/naryMap/BPlusTreeMap.java
+++ b/chaos-tree/src/main/java/chaos/tree/naryMap/BPlusTreeMap.java
@@ -653,6 +653,32 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
             }
         }
 
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BPlusTreeMapNode<K, V> node = rightEdge[0];
+            BPlusTreeMapNode<K, V> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BPlusTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = leftSib.keys[leftSib.keyCount - 1];
+                node.values[0] = leftSib.values[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.values[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+                parent.keys[childIdx - 1] = node.keys[0];
+            } else {
+                parent.keys[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+
+                leftSib.next = node.next;
+                if (leftSib.next != null) {
+                    leftSib.next.prev = leftSib;
+                }
+            }
+        }
+
         for (int level = 1; level < 32; level++) {
             BPlusTreeMapNode<K, V> node = rightEdge[level];
             if (node == null) break;
@@ -661,20 +687,30 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
                 int childIdx = parent.keyCount;
                 BPlusTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
 
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                if (node.child[0] != null) node.child[0].parent = node;
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+                    if (node.child[0] != null) node.child[0].parent = node;
 
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
         this.modCount++;
     }
@@ -702,7 +738,7 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
         if (totalSize == 0) return;
 
         int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
-        BPlusTreeMapNode<K, V>[] rightEdge = (BPlusTreeMapNode<K, V>[]) new BPlusTreeMapNode[32];
+        BPlusTreeMapNode<K, V>[] rightEdge = (BPlusTreeMapNode<K, V>[]) new BPlusTreeMapNode[10];
         rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
 
@@ -753,7 +789,33 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
             }
         }
 
-        for (int level = 1; level < 32; level++) {
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BPlusTreeMapNode<K, V> node = rightEdge[0];
+            BPlusTreeMapNode<K, V> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BPlusTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = leftSib.keys[leftSib.keyCount - 1];
+                node.values[0] = leftSib.values[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.values[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+                parent.keys[childIdx - 1] = node.keys[0];
+            } else {
+                parent.keys[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+
+                leftSib.next = node.next;
+                if (leftSib.next != null) {
+                    leftSib.next.prev = leftSib;
+                }
+            }
+        }
+
+        for (int level = 1; level < 10; level++) {
             BPlusTreeMapNode<K, V> node = rightEdge[level];
             if (node == null) break;
             if (node.keyCount == 0 && node != this.root) {
@@ -761,20 +823,30 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
                 int childIdx = parent.keyCount;
                 BPlusTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
 
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                node.child[0].parent = node;
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+                    if (node.child[0] != null) node.child[0].parent = node;
 
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
 
         this.size = totalSize;

--- a/chaos-tree/src/main/java/chaos/tree/naryMap/BPlusTreeMap.java
+++ b/chaos-tree/src/main/java/chaos/tree/naryMap/BPlusTreeMap.java
@@ -585,7 +585,6 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
     @Override
     @SuppressWarnings("unchecked")
     public void buildFromSorted(Iterator<? extends Map.Entry<? extends K, ? extends V>> it, float factor) {
-
         if (!isEmpty()) {
             throw new IllegalStateException("Bulk load is only permitted on an empty tree.");
         }
@@ -619,8 +618,7 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
                 newLeaf.keyCount = 1;
                 this.size++;
 
-                K routingKey;
-                routingKey = key;
+                K routingKey = key;
                 BPlusTreeMapNode<K, V> leftChild = leaf;
                 BPlusTreeMapNode<K, V> rightChild = newLeaf;
 
@@ -633,8 +631,6 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
                     if (parent == null) {
                         parent = createNode(degree, false);
                         parent.setChild(0, leftChild);
-                        leftChild.parent = parent;
-
                         rightEdge[level] = parent;
                         this.root = parent;
                     }
@@ -642,14 +638,11 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
                     if (parent.keyCount < targetKeys) {
                         parent.keys[parent.keyCount] = routingKey;
                         parent.setChild(parent.keyCount + 1, rightChild);
-                        rightChild.parent = parent;
                         parent.keyCount++;
                         break;
                     } else {
                         BPlusTreeMapNode<K, V> newInternal = createNode(degree, false);
                         newInternal.setChild(0, rightChild);
-                        rightChild.parent = newInternal;
-
                         rightEdge[level] = newInternal;
 
                         leftChild = parent;
@@ -658,6 +651,30 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
                     }
                 }
             }
+        }
+
+        for (int level = 1; level < 32; level++) {
+            BPlusTreeMapNode<K, V> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BPlusTreeMapNode<K, V> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BPlusTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                if (node.child[0] != null) node.child[0].parent = node;
+
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
         }
         this.modCount++;
     }
@@ -666,82 +683,98 @@ public final class BPlusTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BPlusTre
     @SuppressWarnings("unchecked")
     public void importFlatMatrix(Object[][] blast, float factor) {
         if (blast == null || blast.length == 0) return;
-
         if (blast.length < 2 || blast[0].length != blast[1].length) {
             throw new IllegalArgumentException("Key and value size mismatch");
         }
         if (!isEmpty()) {
             throw new IllegalStateException("Bulk load is only permitted on an empty tree.");
         }
-
         if (degree < 32) {
             throw new IllegalStateException("Bulk load is only supported for large chunks; degree must be at least 32.");
         }
-
         if (factor < 0.5f || factor > 1.0f) {
             throw new IllegalArgumentException("Fill factor must be between 0.5 and 1.0");
         }
+
         Object[] inKeys = blast[0];
         Object[] inValues = blast[1];
         int totalSize = inKeys.length;
-
         if (totalSize == 0) return;
 
         int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
         BPlusTreeMapNode<K, V>[] rightEdge = (BPlusTreeMapNode<K, V>[]) new BPlusTreeMapNode[32];
+        rightEdge[0] = createNode(degree, true);
+        this.root = rightEdge[0];
 
         int i = 0;
         while (i < totalSize) {
-            int chunk = Math.min(targetKeys, totalSize - i);
-            BPlusTreeMapNode<K, V> leaf = createNode(degree, true);
-            System.arraycopy(inKeys, i, leaf.keys, 0, chunk);
-            System.arraycopy(inValues, i, leaf.values, 0, chunk);
-            leaf.keyCount = chunk;
+            BPlusTreeMapNode<K, V> leaf = rightEdge[0];
+            int chunk = Math.min(targetKeys - leaf.keyCount, totalSize - i);
+            System.arraycopy(inKeys, i, leaf.keys, leaf.keyCount, chunk);
+            System.arraycopy(inValues, i, leaf.values, leaf.keyCount, chunk);
+            leaf.keyCount += chunk;
+            i += chunk;
 
-            if (i == 0) {
-                rightEdge[0] = leaf;
-                this.root = leaf;
-            } else {
-                BPlusTreeMapNode<K, V> prevLeaf = rightEdge[0];
-                prevLeaf.next = leaf;
-                leaf.prev = prevLeaf;
-                K routingKey = (K) inKeys[i];
-                BPlusTreeMapNode<K, V> leftChild = prevLeaf;
-                BPlusTreeMapNode<K, V> rightChild = leaf;
-
-                rightEdge[0] = leaf;
+            if (i < totalSize) {
+                K routingKey = (K) inKeys[i]; // B+Tree doesn't consume the element
 
                 int level = 1;
                 while (true) {
                     BPlusTreeMapNode<K, V> parent = rightEdge[level];
-
                     if (parent == null) {
                         parent = createNode(degree, false);
-                        parent.setChild(0, leftChild);
-                        leftChild.parent = parent;
+                        parent.setChild(0, rightEdge[level - 1]);
                         rightEdge[level] = parent;
                         this.root = parent;
                     }
 
                     if (parent.keyCount < targetKeys) {
                         parent.keys[parent.keyCount] = routingKey;
-                        parent.setChild(parent.keyCount + 1, rightChild);
-                        rightChild.parent = parent;
                         parent.keyCount++;
+
+                        BPlusTreeMapNode<K, V> prevInternal = parent;
+                        for (int d = level - 1; d >= 0; d--) {
+                            BPlusTreeMapNode<K, V> newNode = createNode(degree, d == 0);
+                            prevInternal.setChild(prevInternal.keyCount, newNode);
+
+                            if (d == 0) {
+                                rightEdge[0].next = newNode;
+                                newNode.prev = rightEdge[0];
+                            }
+
+                            rightEdge[d] = newNode;
+                            prevInternal = newNode;
+                        }
                         break;
                     } else {
-                        BPlusTreeMapNode<K, V> newInternal = createNode(degree, false);
-                        newInternal.setChild(0, rightChild);
-                        rightChild.parent = newInternal;
-                        rightEdge[level] = newInternal;
-
-                        leftChild = parent;
-                        rightChild = newInternal;
                         level++;
                     }
                 }
             }
-            i += chunk;
+        }
+
+        for (int level = 1; level < 32; level++) {
+            BPlusTreeMapNode<K, V> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BPlusTreeMapNode<K, V> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BPlusTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                node.child[0].parent = node;
+
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
         }
 
         this.size = totalSize;

--- a/chaos-tree/src/main/java/chaos/tree/naryMap/BTreeMap.java
+++ b/chaos-tree/src/main/java/chaos/tree/naryMap/BTreeMap.java
@@ -525,7 +525,6 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
     void buildFromSorted(Iterator<? extends Map.Entry<? extends K, ? extends V>> it, float factor) {
         int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
         BTreeMapNode<K, V>[] rightEdge = (BTreeMapNode<K, V>[]) new BTreeMapNode[32];
-
         rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
 
@@ -546,11 +545,9 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                 int level = 1;
                 while (true) {
                     BTreeMapNode<K, V> parent = rightEdge[level];
-
                     if (parent == null) {
                         parent = createNode(degree, false);
                         parent.setChild(0, rightEdge[level - 1]);
-                        rightEdge[level - 1].parent = parent;
                         rightEdge[level] = parent;
                         this.root = parent;
                     }
@@ -564,8 +561,6 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                         for (int d = level - 1; d >= 0; d--) {
                             BTreeMapNode<K, V> newNode = createNode(degree, d == 0);
                             prevInternal.setChild(prevInternal.keyCount, newNode);
-                            newNode.parent = prevInternal;
-
                             rightEdge[d] = newNode;
                             prevInternal = newNode;
                         }
@@ -576,8 +571,33 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                 }
             }
         }
+
+        for (int level = 1; level < 32; level++) {
+            BTreeMapNode<K, V> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BTreeMapNode<K, V> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.values[0] = parent.values[childIdx - 1];
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                if (node.child[0] != null) node.child[0].parent = node;
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1];
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
+        }
         this.modCount++;
     }
+
 
     @SuppressWarnings("unchecked")
     public void importFlatMatrix(Object[][] blast, float factor) {
@@ -652,6 +672,33 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                     }
                 }
             }
+        }
+        for (int level = 1; level < 32; level++) {
+            BTreeMapNode<K, V> node = rightEdge[level];
+            if (node == null) break;
+            if (node.keyCount == 0 && node != this.root) {
+                BTreeMapNode<K, V> parent = rightEdge[level + 1];
+                int childIdx = parent.keyCount;
+                BTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.values[0] = parent.values[childIdx - 1]; // Swap value!
+
+                node.child[1] = node.child[0];
+                node.child[0] = leftSib.child[leftSib.keyCount];
+                if (node.child[0] != null) node.child[0].parent = node;
+
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1]; // Swap value!
+
+                leftSib.child[leftSib.keyCount] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            }
+        }
+        while (!this.root.isLeaf() && this.root.keyCount == 0) {
+            this.root = this.root.child[0];
+            this.root.parent = null;
         }
         this.size = totalSize;
         this.modCount++;

--- a/chaos-tree/src/main/java/chaos/tree/naryMap/BTreeMap.java
+++ b/chaos-tree/src/main/java/chaos/tree/naryMap/BTreeMap.java
@@ -572,6 +572,32 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
             }
         }
 
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BTreeMapNode<K, V> node = rightEdge[0];
+            BTreeMapNode<K, V> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.values[0] = parent.values[childIdx - 1];
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.values[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            } else {
+                leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                leftSib.values[leftSib.keyCount] = parent.values[childIdx - 1];
+                leftSib.keyCount++;
+                parent.keys[childIdx - 1] = null;
+                parent.values[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+            }
+        }
+
         for (int level = 1; level < 32; level++) {
             BTreeMapNode<K, V> node = rightEdge[level];
             if (node == null) break;
@@ -579,21 +605,36 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                 BTreeMapNode<K, V> parent = rightEdge[level + 1];
                 int childIdx = parent.keyCount;
                 BTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.values[0] = parent.values[childIdx - 1];
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                if (node.child[0] != null) node.child[0].parent = node;
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1];
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.values[0] = parent.values[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+                    if (node.child[0] != null) node.child[0].parent = node;
+
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.values[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.values[leftSib.keyCount] = parent.values[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
+
+                    parent.keys[childIdx - 1] = null;
+                    parent.values[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
         this.modCount++;
     }
@@ -623,7 +664,7 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
         if (totalSize == 0) return;
 
         int targetKeys = Math.max(minKeys, (int) (maxKeys * factor));
-        BTreeMapNode<K, V>[] rightEdge = (BTreeMapNode<K, V>[]) new BTreeMapNode[32];
+        BTreeMapNode<K, V>[] rightEdge = (BTreeMapNode<K, V>[]) new BTreeMapNode[10];
 
         rightEdge[0] = createNode(degree, true);
         this.root = rightEdge[0];
@@ -673,7 +714,32 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                 }
             }
         }
-        for (int level = 1; level < 32; level++) {
+        if (rightEdge[0] != null && rightEdge[0].keyCount == 0 && rightEdge[0] != this.root) {
+            BTreeMapNode<K, V> node = rightEdge[0];
+            BTreeMapNode<K, V> parent = rightEdge[1];
+            int childIdx = parent.keyCount;
+            BTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
+
+            if (leftSib.keyCount > minKeys) {
+                node.keys[0] = parent.keys[childIdx - 1];
+                node.values[0] = parent.values[childIdx - 1];
+                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1];
+                leftSib.keys[leftSib.keyCount - 1] = null;
+                leftSib.values[leftSib.keyCount - 1] = null;
+                leftSib.keyCount--;
+                node.keyCount++;
+            } else {
+                leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                leftSib.values[leftSib.keyCount] = parent.values[childIdx - 1];
+                leftSib.keyCount++;
+                parent.keys[childIdx - 1] = null;
+                parent.values[childIdx - 1] = null;
+                parent.child[childIdx] = null;
+                parent.keyCount--;
+            }
+        }
+        for (int level = 1; level < 10; level++) {
             BTreeMapNode<K, V> node = rightEdge[level];
             if (node == null) break;
             if (node.keyCount == 0 && node != this.root) {
@@ -681,24 +747,35 @@ public final class BTreeMap<K, V> extends AbstractNaryTreeMap<K, V, BTreeMapNode
                 int childIdx = parent.keyCount;
                 BTreeMapNode<K, V> leftSib = parent.child[childIdx - 1];
 
-                node.keys[0] = parent.keys[childIdx - 1];
-                node.values[0] = parent.values[childIdx - 1]; // Swap value!
+                if (leftSib.keyCount > minKeys) {
+                    node.keys[0] = parent.keys[childIdx - 1];
+                    node.values[0] = parent.values[childIdx - 1];
+                    node.child[1] = node.child[0];
+                    node.child[0] = leftSib.child[leftSib.keyCount];
+                    if (node.child[0] != null) node.child[0].parent = node;
 
-                node.child[1] = node.child[0];
-                node.child[0] = leftSib.child[leftSib.keyCount];
-                if (node.child[0] != null) node.child[0].parent = node;
+                    parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
+                    parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1];
+                    leftSib.keys[leftSib.keyCount - 1] = null;
+                    leftSib.values[leftSib.keyCount - 1] = null;
+                    leftSib.child[leftSib.keyCount] = null;
+                    leftSib.keyCount--;
+                    node.keyCount++;
+                } else {
+                    leftSib.keys[leftSib.keyCount] = parent.keys[childIdx - 1];
+                    leftSib.values[leftSib.keyCount] = parent.values[childIdx - 1];
+                    leftSib.child[leftSib.keyCount + 1] = node.child[0];
+                    if (leftSib.child[leftSib.keyCount + 1] != null) {
+                        leftSib.child[leftSib.keyCount + 1].parent = leftSib;
+                    }
+                    leftSib.keyCount++;
 
-                parent.keys[childIdx - 1] = leftSib.keys[leftSib.keyCount - 1];
-                parent.values[childIdx - 1] = leftSib.values[leftSib.keyCount - 1]; // Swap value!
-
-                leftSib.child[leftSib.keyCount] = null;
-                leftSib.keyCount--;
-                node.keyCount++;
+                    parent.keys[childIdx - 1] = null;
+                    parent.values[childIdx - 1] = null;
+                    parent.child[childIdx] = null;
+                    parent.keyCount--;
+                }
             }
-        }
-        while (!this.root.isLeaf() && this.root.keyCount == 0) {
-            this.root = this.root.child[0];
-            this.root.parent = null;
         }
         this.size = totalSize;
         this.modCount++;

--- a/chaos-tree/src/test/java/chaos/tree/ChaosTreeEngineTest.java
+++ b/chaos-tree/src/test/java/chaos/tree/ChaosTreeEngineTest.java
@@ -21,23 +21,30 @@ public class ChaosTreeValidator {
         }
 
         Object[][] flatMatrix = new Object[][]{keys, values};
-        BPlusTreeMap<Integer, String> chaosTree =
-                BPlusTreeMap.Builder.<Integer, String>degree(64)
-                        .factor(1.0f) //full packing is used 1f 100% node are filled except last one.
-                        .importFlatMatrix(flatMatrix)
-                        .build();
 
-        boolean passed = true;
+        for(int degree = 32; degree <= 200;degree++){
+            float f = 0.5f;
+            for(int i =0;i<5;i++){
+                f += 0.1f;
+                if(f>1f) f = 1f;
+                BPlusTreeMap<Integer, String> chaosTree =
+                        BPlusTreeMap.Builder.<Integer, String>degree(degree)
+                                .factor(f) //full packing is used 1f 100% node are filled except last one.
+                                .importFlatMatrix(flatMatrix)
+                                .build();
+                boolean passed = true;
 
-        passed &= verifySize(truthMap, chaosTree);
-        passed &= verifyExactGets(truthMap, chaosTree, keys);
-        passed &= verifyIteration(truthMap, chaosTree);
-        passed &= verifyRandomDeletionGauntlet(chaosTree,keys);
+                passed &= verifySize(truthMap, chaosTree);
+                passed &= verifyExactGets(truthMap, chaosTree, keys);
+                passed &= verifyIteration(truthMap, chaosTree);
+                passed &= verifyRandomDeletionGauntlet(chaosTree,keys);
 
-        if (passed) {
-            System.out.println("SUCCESS: ChaosTree is structurally sound and mathematically identical to JDK TreeMap.");
-        } else {
-            System.err.println("Doomed by the way: ChaosTree has data corruption or invariant violations thanks by the way :(");
+                if (passed) {
+                    System.out.println("SUCCESS: ChaosTree is structurally sound and mathematically identical to JDK TreeMap.");
+                } else {
+                    System.err.println("Doomed by the way: ChaosTree has data corruption or invariant violations thanks by the way :(");
+                }
+            }
         }
     }
 

--- a/chaos-tree/src/test/java/chaos/tree/binaryMap/AvlTreeMapTest.java
+++ b/chaos-tree/src/test/java/chaos/tree/binaryMap/AvlTreeMapTest.java
@@ -6,10 +6,11 @@ import com.google.common.collect.testing.features.CollectionFeature;
 import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import junit.framework.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.SortedMap;
-
+@RunWith(org.junit.runners.AllTests.class)
 public class AvlTreeMapTest {
     public static Test suite() {
         return NavigableMapTestSuiteBuilder
@@ -31,6 +32,8 @@ public class AvlTreeMapTest {
                         MapFeature.RESTRICTS_KEYS,
                         CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                         CollectionFeature.KNOWN_ORDER,
+                        CollectionFeature.SUBSET_VIEW,
+                        CollectionFeature.DESCENDING_VIEW,
                         CollectionSize.ANY,
                         CollectionFeature.SERIALIZABLE,
                         MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION

--- a/chaos-tree/src/test/java/chaos/tree/binaryMap/RedBlackTreeMapTest.java
+++ b/chaos-tree/src/test/java/chaos/tree/binaryMap/RedBlackTreeMapTest.java
@@ -6,10 +6,11 @@ import com.google.common.collect.testing.features.CollectionFeature;
 import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import junit.framework.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.SortedMap;
-
+@RunWith(org.junit.runners.AllTests.class)
 public class RedBlackTreeMapTest {
     public static Test suite() {
         return NavigableMapTestSuiteBuilder
@@ -32,6 +33,8 @@ public class RedBlackTreeMapTest {
                         CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                         CollectionFeature.KNOWN_ORDER,
                         CollectionSize.ANY,
+                        CollectionFeature.SUBSET_VIEW,
+                        CollectionFeature.DESCENDING_VIEW,
                         CollectionFeature.SERIALIZABLE,
                         MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION
                 )

--- a/chaos-tree/src/test/java/chaos/tree/naryMap/BPlusTreeMapTest.java
+++ b/chaos-tree/src/test/java/chaos/tree/naryMap/BPlusTreeMapTest.java
@@ -7,10 +7,11 @@ import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import junit.framework.Test;
 import junit.framework.TestCase;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.SortedMap;
-
+@RunWith(org.junit.runners.AllTests.class)
 public class BPlusTreeMapTest extends TestCase {
 
     public static Test suite() {
@@ -33,6 +34,8 @@ public class BPlusTreeMapTest extends TestCase {
                         MapFeature.RESTRICTS_KEYS,
                         CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                         CollectionFeature.KNOWN_ORDER,
+                        CollectionFeature.SUBSET_VIEW,
+                        CollectionFeature.DESCENDING_VIEW,
                         CollectionSize.ANY,
                         CollectionFeature.SERIALIZABLE,
                         MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION

--- a/chaos-tree/src/test/java/chaos/tree/naryMap/BTreeMapTest.java
+++ b/chaos-tree/src/test/java/chaos/tree/naryMap/BTreeMapTest.java
@@ -7,10 +7,11 @@ import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import junit.framework.Test;
 import junit.framework.TestCase;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.SortedMap;
-
+@RunWith(org.junit.runners.AllTests.class)
 public class BTreeMapTest extends TestCase {
     public static Test suite() {
         return NavigableMapTestSuiteBuilder
@@ -33,6 +34,8 @@ public class BTreeMapTest extends TestCase {
                         CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                         CollectionFeature.KNOWN_ORDER,
                         CollectionSize.ANY,
+                        CollectionFeature.SUBSET_VIEW,
+                        CollectionFeature.DESCENDING_VIEW,
                         CollectionFeature.SERIALIZABLE,
                         MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION
                 )


### PR DESCRIPTION
## Fix NPE and AIOOBE for NaryFamily buld of O(N) 

Fixes correctness issues in the Core tree implementations affecting
Set/Map operations.
caused by function 
- buildFromSorted()
- importFromMatrix()

The fixes cover incorrect behavior found during randomized testing,
contract testing, and cross-validation against JDK/Guava collections.

## Root Cause

The issues were caused by internal leaf corruption voilation the CLRS system and throwing AIOOBE
and under rigrous test for remove it just collapse with NPE.

## Changes

- Updated `AbstractNaryTreeSet`.
- Updated `AbstractNaryTreeSet`.


## Validation

The changes were validated using:

- JUnit test suite
- Randomized testing
- Cross-validation against JDK `TreeMap` / `TreeSet` -These act as truth tester
- Guava Testlib

All existing tests pass.

## Scope

This PR only targets Core correctness fixes.
No intentional API-breaking changes are introduced.

## Checklist
 
Currently the test made is not rigrous and this is snapshot also to make it ensure to have a backup.